### PR TITLE
Update gradle settings to measure extract build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ plugins {
     // https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations
     id "io.gitlab.arturbosch.detekt" version "1.0.0.RC6-3"
     id "org.jetbrains.kotlin.kapt" version "1.2.50"
+    id "com.gradle.build-scan" version "3.6.1"
 }
 
 detekt {
@@ -76,4 +77,12 @@ task ktlint(type: JavaExec, group: "verification") {
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
     args "**/*.kt"
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,7 @@ android.enableR8=true
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Disable some optimizations to measure the exact build time
+org.gradle.daemon=false
+org.gradle.caching=false


### PR DESCRIPTION
This will help you measure objective build times.

* Disabled gradle build cache and daemon
* Enabled gradle build scan